### PR TITLE
Redo hero / main heading + element order

### DIFF
--- a/web/system/modules/no.npolar.common.ivorypage/elements/ivorypage.jsp
+++ b/web/system/modules/no.npolar.common.ivorypage/elements/ivorypage.jsp
@@ -199,30 +199,30 @@ while (container.hasMoreContent()) {
             byline = CmsAgent.obfuscateEmailAddr(byline, false);
     }
     */
-    if (CmsAgent.elementExists(pageTitle)) {
+    %>
+    <h1 class="main-article__title"><span class="textwrap"><%= pageTitle %></span></h1>
+    <%
+    //if (CmsAgent.elementExists(pageTitle)) {
         if (cms.elementExists(imgUri)) {
         %>
 
 
-        <section class="article-hero">
-            <div class="article-hero-content">
-                <h1><%= pageTitle %></h1>
+        <div class="article-hero hero hero--top main-article__hero">
+            <div class="article-hero-content hero__content">
+                <!--<h1><%= pageTitle %></h1>-->
                 <figure>
                     <!--<img src="<%= cms.link(imgUri) %>" alt="" />-->
                     <%= ImageUtil.getImage(cms, imgUri) %>
                     <figcaption><%= cms.property("byline", imgUri, "") %></figcaption>
                 </figure>            
             </div>
-        </section>
-        <%
-        } else {
-        %>
-        <h1><%= pageTitle %></h1>
+        </div>
         <%
         }
-    }
-    if (byline != null)
+    //}
+    if (byline != null) {
         out.println(byline);
+    }
     /*
     if (redListStatus != null) 
         out.println("<div class=\"redlist-status\"><p>" + TITLE_RED_LIST_STATUS + ": " + redListStatus + "</p></div>");
@@ -230,7 +230,7 @@ while (container.hasMoreContent()) {
     if (CmsAgent.elementExists(pageIntro)) {
         try { pageIntro = cnr.resolve(pageIntro); } catch (Exception e) {}
         %>
-        <section class="descr" id="page-summary"><%= pageIntro %></section><!-- .ingress -->
+        <section class="descr main-article__descr" id="page-summary"><%= pageIntro %></section><!-- .ingress -->
         <%
     }
 

--- a/web/system/modules/no.npolar.common.portalpage/elements/portalpage.jsp
+++ b/web/system/modules/no.npolar.common.portalpage/elements/portalpage.jsp
@@ -191,24 +191,30 @@ while (container.hasMoreContent()) {
     //out.println("<div class=\"fourcol-equal double left\">");
     //out.println("<div class=\"portal left\">");
     //out.println("<article class=\"main-content portal\">");
-    
-    if (!heroImageHtml.isEmpty()) {
-        out.println("<div class=\"article-hero\">");
-        out.println("<div class=\"article-hero-content\">");
-    }
     // Title and page intro
     if (CmsAgent.elementExists(pageTitle)) {
-        out.println("<h1>" + pageTitle + "</h1>");
+        %>
+        <h1 class="main-article__title"><span class="textwrap"><%= pageTitle %></span></h1>
+        <%
     }
     
     if (!heroImageHtml.isEmpty()) {
-        out.println(heroImageHtml);
-        if (CmsAgent.elementExists(pageIntro) && pageIntroAsOverlay) {
-            try { pageIntro = cnr.resolve(pageIntro); } catch (Exception e) {}
-            out.println("<section class=\"descr overlay\"" + (CmsAgent.elementExists(pageIntroStyle) ? (" style=\""+pageIntroStyle+"\"") : "") + ">" + pageIntro + "</section>");
-        }
-        out.println("</div><!-- .article-hero-content -->");  
-        out.println("</div><!-- .article-hero -->");   
+        %>
+        <div class="article-hero hero hero--top main-article__hero">
+            <div class="article-hero-content hero__content">
+                <%
+                out.println(heroImageHtml);
+                if (CmsAgent.elementExists(pageIntro) && pageIntroAsOverlay) {
+                    try { pageIntro = cnr.resolve(pageIntro); } catch (Exception e) {}
+                    out.println("<section class=\"descr overlay\"" 
+                                + (CmsAgent.elementExists(pageIntroStyle) ? (" style=\""+pageIntroStyle+"\"") : "") + ">" 
+                                    + pageIntro 
+                                + "</section>");
+                }
+                %>
+            </div><!-- .article-hero-content -->
+        </div><!-- .article-hero -->
+        <%
     }
     
     

--- a/web/system/modules/no.npolar.mosj/elements/frontpage.jsp
+++ b/web/system/modules/no.npolar.mosj/elements/frontpage.jsp
@@ -68,14 +68,14 @@ String summary = "<p>"
         ) + "</p>";
     
     %>
-    
-    <section class="article-hero">
-        <div class="article-hero-content">
-            <h1 class="hidden"><%= title %></h1>
+    <h1 class="hidden"><%= title %></h1>
+    <div class="article-hero hero hero--top main-article__hero">
+        <div class="article-hero-content hero__content">
+            <!--<h1 class="hidden"><%= title %></h1>-->
             <figure>
                 <%= ImageUtil.getImage(cms, imgUri, null) %>
                 <!--<img src="<%= cms.link(imgUri) %>" alt="" />-->
-                <figcaption><%= cms.property("byline", imgUri, "") %></figcaption>
+                <figcaption><span class="credit"><%= cms.property("byline", imgUri, "") %></span></figcaption>
             </figure>
             
             <div class="frontpage-searchbox-wrap">
@@ -88,9 +88,9 @@ String summary = "<p>"
                 </form>
             </div>
         </div>
-    </section>
+    </div>
         
-    <section class="descr" style="text-align:center;">
+    <section class="descr main-article__descr" style="text-align:center;">
         <%= summary %>
     </section>
     

--- a/web/system/modules/no.npolar.mosj/elements/indicator.jsp
+++ b/web/system/modules/no.npolar.mosj/elements/indicator.jsp
@@ -270,29 +270,28 @@ while (structuredContent.hasMoreResources()) {
         if (!latinName.trim().isEmpty())
             title = title + " <span class=\"scientific-name\">(" + latinName + ")</span>";
     }
+    %>
+    <h1 class="main-article__title"><span class="textwrap"><%= title %></span></h1>
+    <%
     
     if (cms.elementExists(imgUri)) {
     %>
     
     
-    <section class="article-hero">
-        <div class="article-hero-content">
-            <h1><%= title %></h1>
+    <div class="article-hero hero hero--top main-article__hero">
+        <div class="article-hero-content hero__content">
+            <!--<h1><%= title %></h1>-->
             <figure>
                 <!--<img src="<%= cms.link(imgUri) %>" alt="" />-->
                 <%= ImageUtil.getImage(cms, imgUri) %>
-                <figcaption><%= cms.property("byline", imgUri, "") %></figcaption>
+                <figcaption><span class="credit"><%= cms.property("byline", imgUri, "") %></span></figcaption>
             </figure>            
         </div>
-    </section>
-    <%
-    } else {
-    %>
-    <h1><%= title %></h1>
+    </div>
     <%
     }
     %>
-    <section class="descr">
+    <section class="descr main-article__descr">
         <% if (lastReleased != null) { %>
         <div class="metadata metadata--page-data"><span class="metadata__timestamp"><%= lastReleased %></span></div> 
         <% } %>

--- a/web/system/modules/no.npolar.mosj/resources/js/commons.js
+++ b/web/system/modules/no.npolar.mosj/resources/js/commons.js
@@ -158,6 +158,13 @@ $.fn.hoverDelay = function(options) {
     });
 };
 
+function prependBreadcrumbToTitle() {
+    'use strict';
+    $('h1').first().before(
+        $('#nav_breadcrumb_wrap')
+    );
+}
+
 /**
  * Handle hash (fragment) change.
  */
@@ -915,6 +922,7 @@ function initUserControls() {
  */
 $(document).ready( function() {
     'use strict';
+    prependBreadcrumbToTitle();
     // Initialize responsive tables
     makeResponsiveTables();
     // Initialize tabbed content (enhancement - works with pure css but not optimal)

--- a/web/system/modules/no.npolar.mosj/resources/style/base.css
+++ b/web/system/modules/no.npolar.mosj/resources/style/base.css
@@ -164,6 +164,7 @@ html,
 div,
 header,
 footer,
+main,
 article, 
 section,
 figure,
@@ -226,6 +227,9 @@ body {
     overflow-x:hidden;
     position:relative;
     width:100%;
+}
+#wrapwrap {
+    background-color: #fff; /* for IE */
 }
 #top {
     background-color:#234;
@@ -463,6 +467,7 @@ h6 {
     
     text-align: center;
     padding-top: 4rem;
+    position: relative; /* for IE */
 }
 .main-article > h1,
 .main-article__title {
@@ -1400,6 +1405,25 @@ a.breadcrumb*/ {
     /*margin: 0;*/
 }
 
+/* Old IE / non-flexbox browsers */
+.no-flexbox .main-content #nav_breadcrumb_wrap,
+.no-flexbox .main-content h1 {
+    background: #0e131f;
+    color: #fff;
+    text-align: left;
+}
+.no-flexbox .main-content #nav_breadcrumb_wrap {
+    padding-top: 0;
+}
+.no-flexbox .main-content #nav_breadcrumb li:first-child {
+    margin-left: -1.75em;
+}
+.no-flexbox .main-content #nav_breadcrumb_wrap,
+.no-flexbox .main-content #nav_breadcrumb, 
+.no-flexbox .main-content #nav_breadcrumb a {
+    font-weight: normal;
+    color: #adf;
+}
 
 /* Accessibility tool: "Skip to main content"-link */
 #skipnav {

--- a/web/system/modules/no.npolar.mosj/resources/style/base.css
+++ b/web/system/modules/no.npolar.mosj/resources/style/base.css
@@ -387,13 +387,14 @@ h1,
     margin-top:0;
     margin-bottom:0;
     padding:0 0.5rem 0.5rem 0.5rem;
-    background-color:#000;
-    color:#fff;
+    /*background-color:#000;*/
+    /*color:#fff;*/
     /*padding-bottom:0.5em;
     padding-top:1em;*/
     /*text-shadow:1px 1px 1px #ddd;*/
 	
     /*border-bottom:0.5em solid #3d667b;*/
+    text-align: center;
 }
 
 h2,
@@ -418,6 +419,58 @@ h4,
 h5,
 h6 {
     font-weight:bold;
+}
+
+/**
+ * Flex the main article so we can control the order of elements. 
+ * E.g. h1 is first, but we want to put it after the hero slot.
+ */
+.main-article {
+    display: flex;
+    flex-direction: column;
+    /* hides blurry bg image => must be set to visible in larger widths */
+    overflow-x: hidden;
+}
+/* Place the hero slot at the very top. */
+.main-article > .hero {
+    order:-1;
+}
+/*.main-article > h1 > .textwrap,
+.main-article__title > .textwrap,*/
+.main-article > h1:after {
+    /* Same red as h2's but opacity adjusted */
+    border-bottom: 2px solid rgba(139, 0, 0, 0.2);
+    content: " ";
+    display: block;
+    width: 5em;
+    margin: 1.2rem auto 0;
+}
+.main-article > h1 .scientific-name,
+.main-article__title .scientific-name {
+    display: block;
+}
+/* Shadow from hero will appear behind main heading & descripiton. Hide them */
+.main-article > h1,
+.main-article > .descr,
+.main-article__title,
+.main-article__descr {
+    margin-left: -9999em;
+    margin-right: -9999em;
+    padding-left: 9999em;
+    padding-right: 9999em;
+    z-index: 2;
+    background: #fff;
+    
+    text-align: center;
+    padding-top: 4rem;
+}
+.main-article > h1,
+.main-article__title {
+}
+.main-article > .descr,
+.main-article__descr {
+    padding-bottom: 4rem;
+    padding-top: 1rem;
 }
 
 /* Direct children of the main content, and direct children of page description / summary */
@@ -453,7 +506,7 @@ h6 {
 }
 .article-hero img {
     width:100%;
-    min-height:10em; /* Visible title, even if image won't load */
+    /*min-height:10em;*/ /* Visible title, even if image won't load */
 }
 .article-hero > img,
 .article-hero > canvas,
@@ -463,6 +516,9 @@ h6 {
 .article-hero,
 .article-hero figure {
     position:relative;
+    margin: 0 -9999em;
+    padding: 0 9999em;
+    padding: 0 calc(9999em - 0.25rem); /* needed to bleed the image off the sides */
 }
 /* Hero caption */
 .article-hero figcaption {
@@ -470,13 +526,18 @@ h6 {
     bottom:0;
     right:0;
     font-size:0.7em;
-    background-color:#777;
-    background-color:rgba(0,0,0,0.4);
-    padding:0.2em 0.5em;
+    /*background-color:#777;
+    background-color:rgba(0,0,0,0.4);*/
+    padding:inherit;
 }
 .article-hero figcaption, 
 .article-hero figcaption a {
     color:#eee;
+}
+.article-hero figcaption > * {
+    background-color: #666;
+    background-color: rgba(0,0,0,0.4);
+    padding: 0.2em 0.5em;
 }
 /* Main headings in running text */
 .paragraph > h2 {
@@ -1062,8 +1123,9 @@ h1 .scientific-name {
     display: block;
     font-size: small;
     color: #6e6e6e;
-    text-align: right;
-    margin-top: -2.95em;
+    text-align: center;
+    margin-top: -1rem;
+    margin-bottom: 1rem;
 }
 .metadata__timestamp:before {
     display: inline-block;
@@ -1242,9 +1304,10 @@ h1 .scientific-name {
 
 /* Breadcrumbs */
 #nav_breadcrumb_wrap {
-    background-color:#111;
-    overflow:auto;
-    border:none;
+    background-color: #111;
+    background-color: rgba(0,0,0,0.25);
+    overflow: auto;
+    border: none;
 }
 #nav_breadcrumb {
     /*list-style-image:none;
@@ -1288,6 +1351,53 @@ a.breadcrumb*/ {
 }
 #homepage #nav_breadcrumb {
     display:none;
+}
+.main-content #nav_breadcrumb_wrap {
+    background: #fff;
+    text-align: center;
+    /*margin-bottom: -4rem;*/ /* pull it down towards the main title */
+    /*margin-top: 4rem;*/
+    margin-left: -9999em;
+    margin-right: -9999em;
+    padding-left: 9999em;
+    padding-right: 9999em;
+    padding-top: 2rem;
+    z-index: 2; /* hide stuff behind this element (hero shadow, figcaption bg) */
+}
+.main-content #nav_breadcrumb_wrap + h1 {
+    padding-top: 0;
+}
+.main-content #nav_breadcrumb,
+.main-content #nav_breadcrumb_wrap,
+.main-content #nav_breadcrumb_wrap a {
+    color: #1572E0;
+    text-shadow: none;
+    font-size: 0.8rem;
+    font-weight: bold;
+}
+.main-content #nav_breadcrumb_wrap a {
+    text-decoration: none;
+    padding: 0.5em;
+    border-radius: 3px;
+}
+.main-content #nav_breadcrumb_wrap a:hover {
+    color: #bd4422;
+    background-color: rgba(0,0,0,0.05);
+    border-radius: 3px;
+}
+.main-content #nav_breadcrumb li {
+    float: none;
+    display: inline;
+    margin: 0;
+}
+.main-content #nav_breadcrumb li:first-child {
+    /*margin-left: 0.5em;*/ /* needed for perfect centering */
+    /*margin: 0;*/
+}
+.main-content #nav_breadcrumb li:last-child,
+.homepage .main-content #nav_breadcrumb_wrap {
+    display: none;
+    /*margin: 0;*/
 }
 
 
@@ -2826,8 +2936,10 @@ a .overlay {
     text-shadow:1px 1px 1px #000;
     color:#fff;
     line-height: 1.4em;	
-    background:#4C4C4C; /* The resulting color of 0.7-opacity black over white */
+    background: #4C4C4C; /* = 0.7 opacity black over white */
     background:rgba(0,0,0,0.7);
+    background: #737373; /* = 0.55 opacity black over white */
+    background: rgba(0,0,0,0.55);
 }
 .overlay > span {
     padding:1% 2%;
@@ -2844,7 +2956,7 @@ section h3.section-heading {
 }
 
 .indicators-list .card {
-    min-height: 12em; /* Visible title even if images won't load */
+    /*min-height: 12em;*/ /* Visible title even if images won't load (no longer a problem)*/
     max-height: 12em;
     overflow: hidden;
     transition: all 0.5s ease-in-out;
@@ -2864,8 +2976,8 @@ section h3.section-heading {
     padding: 0.2em 1em;
     position: absolute;
     right: auto;
-    text-shadow: 0 0 2px rgba(0, 0, 0, 0.99);
-    top: 1em;
+    text-shadow: 0 0 0.1em rgba(0, 0, 0, 0.99);
+    top: 0;
     /*transform: translate(-50%, 1em);*/
     width: auto;
 }

--- a/web/system/modules/no.npolar.mosj/resources/style/base.css
+++ b/web/system/modules/no.npolar.mosj/resources/style/base.css
@@ -639,6 +639,7 @@ section {
 }
 
 .hidden {
+    position: absolute !important;
     font-size:1px;
     height:1px;
     width:1px;
@@ -1351,9 +1352,7 @@ a.breadcrumb*/ {
 #nav_breadcrumb a:hover {
     text-decoration:none;
 }
-#homepage #nav_breadcrumb_wrap {
-    position:static;
-}
+#homepage #nav_breadcrumb_wrap,
 #homepage #nav_breadcrumb {
     display:none;
 }

--- a/web/system/modules/no.npolar.mosj/resources/style/base.css
+++ b/web/system/modules/no.npolar.mosj/resources/style/base.css
@@ -458,7 +458,7 @@ h6 {
     margin-right: -9999em;
     padding-left: 9999em;
     padding-right: 9999em;
-    z-index: 2;
+    z-index: 3;
     background: #fff;
     
     text-align: center;
@@ -1362,7 +1362,7 @@ a.breadcrumb*/ {
     padding-left: 9999em;
     padding-right: 9999em;
     padding-top: 2rem;
-    z-index: 2; /* hide stuff behind this element (hero shadow, figcaption bg) */
+    z-index: 3; /* hide stuff behind this element (hero shadow, figcaption bg) */
 }
 .main-content #nav_breadcrumb_wrap + h1 {
     padding-top: 0;

--- a/web/system/modules/no.npolar.mosj/resources/style/base.css
+++ b/web/system/modules/no.npolar.mosj/resources/style/base.css
@@ -438,6 +438,7 @@ h6 {
 /* Place the hero slot at the very top. */
 .main-article > .hero {
     order:-1;
+    background-color: #0e131f;
 }
 /*.main-article > h1 > .textwrap,
 .main-article__title > .textwrap,*/
@@ -476,6 +477,9 @@ h6 {
 .main-article__descr {
     padding-bottom: 4rem;
     padding-top: 1rem;
+}
+#homepage .main-article__descr {
+    padding-top: 2rem;
 }
 
 /* Direct children of the main content, and direct children of page description / summary */

--- a/web/system/modules/no.npolar.mosj/resources/style/largescreens.css
+++ b/web/system/modules/no.npolar.mosj/resources/style/largescreens.css
@@ -41,8 +41,8 @@
 #search-global, 
 .main-content > *,
 .descr > *,
-.article-hero h1,
-.article-hero figcaption {
+.article-hero h1/*,
+.article-hero figcaption*/ {
     padding:0 1.2rem;
 }
 /*
@@ -62,6 +62,7 @@
     background-position: center 55%;
     /*padding-top: 2em;*/
     padding-top:1.2em;
+    min-height: 16rem;
 }
 /*#top:after {
     content:"";
@@ -460,9 +461,15 @@ h5 {
 
 
 /* 3-column page layout */
-
+.main-article {
+    overflow-x: visible;
+}
+.main-article__descr > p {
+    padding: 0 4.8rem;
+}
 .main-content {
     overflow:visible;
+    margin-top: -2.5rem; /* = breadcrumb height */
 }
 .main-content > * {
     /*margin:0 auto;
@@ -503,6 +510,14 @@ h5 {
     -webkit-filter:blur(30px) brightness(100%);
     filter:blur(30px) brightness(100%);
     filter:progid:DXImageTransform.Microsoft.Blur(PixelRadius='30');
+    
+    margin: 0 auto;
+    width: 100vw;
+    left: 0;
+    right: 0;
+    width: calc(100vw + 100px);
+    left: calc(1px - 51px);
+    right: calc(1px - 51px);
 }
 
 .article-hero > canvas/*,
@@ -523,19 +538,23 @@ h5 {
 }*/
 .article-hero h1,
 .article-hero figcaption {
-    position:absolute;
+    /*position:absolute;*/
     display:inline-block;
     /*padding:0.2em 1.2rem;*/
     /*padding-top:0.2em;
     padding-bottom:0.2em;*/
-    margin:0;
-    background-color:#777;	
+    /*margin:0;*/
+    /*background-color:#777;	*/
     /*background-color:rgba(0,0,0,0.75);*/
-    text-shadow:0 0 2px #000;
+    /*text-shadow:0 0 2px #000;*/
         
-    padding:0.2em 0.5em;
-    background-color:rgba(0,0,0,0.4);
+    /*padding:0.2em 0.5em;
+    background-color:rgba(0,0,0,0.4);*/
     z-index:9;
+}
+.article-hero,
+.article-hero figure {
+    padding: 0 calc(9999em - 0.6rem); /* needed to bleed the image off the sides */
 }
 .article-hero h1 {
     bottom:0.4em;
@@ -828,6 +847,10 @@ h2.portal-box-heading.overlay,
     top: auto;
     color: #fff;
     font-size: 1.2em;
+    
+    bottom: 0;
+    background: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.7), rgba(0,0,0,0.9));
+    padding-top: 3em;
 }
 .indicators-list .card .portal-box-text.overlay p {
     color:#fff;

--- a/web/system/modules/no.npolar.mosj/resources/style/largescreens.css
+++ b/web/system/modules/no.npolar.mosj/resources/style/largescreens.css
@@ -62,7 +62,8 @@
     background-position: center 55%;
     /*padding-top: 2em;*/
     padding-top:1.2em;
-    min-height: 16rem;
+    padding-bottom: 1.2em;
+    /*min-height: 16rem;*/
 }
 /*#top:after {
     content:"";
@@ -469,14 +470,14 @@ h5 {
 }
 .main-content {
     overflow:visible;
-    margin-top: -2.5rem; /* = breadcrumb height */
+    margin-top: 0; /* = breadcrumb height */
 }
 .main-content > * {
     /*margin:0 auto;
     max-width:1200px;*/
     /*padding:0 1.2rem;*/
-}	
-.main-content > .article-hero {
+}
+.main-content > .article-hero { /* this rule no longer has a target */
     background-color:#000;
     color:#fff;
     max-width:none;
@@ -497,7 +498,7 @@ h5 {
     position:absolute;
     z-index:1;
     /*top:-35%;*/
-    top:-20%;
+    top:-25%;
     max-height:120%;    
     -webkit-backface-visibility: hidden;
     -moz-backface-visibility: hidden;
@@ -598,7 +599,7 @@ h5 {
     background:transparent;
 }
 #navwrap {
-    margin:1em 0 2em 0;
+    margin:1em 0;
 }
 #nav_breadcrumb_wrap {
     /*background-color:rgba(0,0,0,0.75);*/

--- a/web/system/modules/no.npolar.mosj/resources/style/largescreens.css
+++ b/web/system/modules/no.npolar.mosj/resources/style/largescreens.css
@@ -529,6 +529,14 @@ h5 {
     width: 100%;
     height: 120%;
     max-height: 120%;
+    
+    margin: 0 auto;
+    width: 100vw;
+    left: 0;
+    right: 0;
+    width: calc(100vw + 100px);
+    left: calc(1px - 51px);
+    right: calc(1px - 51px);
 }
 /*#hero-canvas-overlay {
     box-shadow:0 0 100px 40px #000 inset;
@@ -921,7 +929,7 @@ h2.portal-box-heading.overlay,
 }
 /* test */
 .cssfilters #top {
-    background:transparent;
+    /*background:transparent;*/
 }
 .cssfilters #nav {
     z-index:9999;

--- a/web/system/modules/no.npolar.mosj/templates/mosj.jsp
+++ b/web/system/modules/no.npolar.mosj/templates/mosj.jsp
@@ -413,7 +413,8 @@ out.println(cms.getHeaderElement(CmsAgent.PROPERTY_HEAD_SNIPPET, requestFileUri)
             
             
     <a id="contentstart"></a>
-    <article class="main-content<%= (portal ? " portal" : "") %>">
+    <main class="main-content<%= (portal ? " portal" : "") %>">
+        <article class="main-article">
 </cms:template>
             
 <cms:template element="contentbody">
@@ -421,7 +422,8 @@ out.println(cms.getHeaderElement(CmsAgent.PROPERTY_HEAD_SNIPPET, requestFileUri)
 </cms:template>
             
 <cms:template element="foot">
-    </article>
+        </article>
+    </main>
         <!--</div>--><!-- #content -->        
     <!--</div>--><!-- #mainwrap -->
     <!--</div>--><!-- #docwrap -->


### PR DESCRIPTION
Changes the design of the primary page elements slightly, and provides more correct semantics due to a change in order of elements.

A new `main` elment is introduced. The `h1` is moved out of the hero section, and positioned to be the first child of the main `article` element.

Flexbox is used to control on-page positioning. The hero image is first, and the title follows. The breadcrumb navigation, which actually sits between the main `header` and the `main` is relocated via js to directly above the `h1`.
